### PR TITLE
fix: remove --pretty flag from storage inspector

### DIFF
--- a/funding.json
+++ b/funding.json
@@ -1,0 +1,5 @@
+{
+    "opRetro": {
+      "projectId": "0x3ec2d572a608cf939eaf7886402320b3b2229610c13bdb5cb0776bd097331e5a"
+    }
+  }

--- a/src/commands/storage-inspector.js
+++ b/src/commands/storage-inspector.js
@@ -14,7 +14,7 @@ async function storageLayoutActiveFile(args) {
     let contractDir = await getContractRootDir(contractPathArray.join("/"));
 
     cp.exec(
-      `cd ${contractDir} && forge inspect --pretty ${contractName} storage`,
+      `cd ${contractDir} && forge inspect ${contractName} storage`,
       (err, stdout, stderr) => {
         if (err) {
           vscode.window.showErrorMessage(
@@ -46,7 +46,7 @@ async function storageLayoutContextMenu(clickedFile, selectedFiles) {
     let contractDir = await getContractRootDir(contractPathArray.join("/"));
 
     cp.exec(
-      `cd ${contractDir} && forge inspect --pretty ${contractName} storage`,
+      `cd ${contractDir} && forge inspect ${contractName} storage`,
       (err, stdout, stderr) => {
         if (err) {
           vscode.window.showErrorMessage(


### PR DESCRIPTION
Per https://github.com/foundry-rs/foundry/pull/9705 `forge inspect <contract_addres> storage` no longer uses the `--pretty` flag - this is now the default behavior.

The current version of vscode-solidity-inspector no longer works with newer versions of forge.

Tested locally and the extension now works as intended